### PR TITLE
Allow non string params

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,12 @@ var React = require('react');
 var newlineRegex = /(\r\n|\n\r|\r|\n)/g;
 
 module.exports = function(str) {
-  if (typeof str != 'string') {
-    throw new TypeError('nl2br requires string');
+  if (typeof str === 'number') {
+    return str;
+  } else if (typeof str !== 'string') {
+    return '';
   }
+
   return str.split(newlineRegex).map(function(line) {
     if (line.match(newlineRegex)) {
       return React.createElement('br');

--- a/test.js
+++ b/test.js
@@ -3,9 +3,39 @@ const React = require('react');
 const assert = require('assert');
 
 describe('nl2br', function(){
-  it('newlines', function(){
+  it('should parse newlines', function(){
     const result = nl2br('aaa\nbbb\nccc\nddd');
     const expected = ['aaa', React.createElement('br'), 'bbb', React.createElement('br'), 'ccc', React.createElement('br'), 'ddd'];
+    assert.deepEqual(expected, result);
+  });
+
+  it('should return numbers', function (){
+    const result = nl2br(42);
+    const expected = 42;
+    assert.deepEqual(expected, result);
+  });
+
+  it('should return an empty string if the param is undefined', function () {
+    const result = nl2br(undefined);
+    const expected = '';
+    assert.deepEqual(expected, result);
+  });
+
+  it('should return an empty string if the param is null', function () {
+    const result = nl2br(null);
+    const expected = '';
+    assert.deepEqual(expected, result);
+  });
+
+  it('should return an empty string if the param is an array', function () {
+    const result = nl2br([]);
+    const expected = '';
+    assert.deepEqual(expected, result);
+  });
+
+  it('should return an empty string if the param is an object', function () {
+    const result = nl2br({});
+    const expected = '';
     assert.deepEqual(expected, result);
   });
 });


### PR DESCRIPTION
Rather than throwing an error if the param is not a string returns :
 - the given number if `str` is a number
 - an empty string otherwise