### PR TITLE
append key for each br element

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,10 +10,9 @@ module.exports = function(str) {
     return '';
   }
 
-  var index = 0;
-  return str.split(newlineRegex).map(function(line) {
+  return str.split(newlineRegex).map(function(line, index) {
     if (line.match(newlineRegex)) {
-      return React.createElement('br', { key: index++ });
+      return React.createElement('br', { key: index });
     } else {
       return line;
     }

--- a/index.js
+++ b/index.js
@@ -10,9 +10,10 @@ module.exports = function(str) {
     return '';
   }
 
+  var index = 0;
   return str.split(newlineRegex).map(function(line) {
     if (line.match(newlineRegex)) {
-      return React.createElement('br');
+      return React.createElement('br', { key: index++ });
     } else {
       return line;
     }

--- a/test.js
+++ b/test.js
@@ -7,11 +7,11 @@ describe('nl2br', function(){
     const result = nl2br('aaa\nbbb\nccc\nddd');
     const expected = [
       'aaa',
-      React.createElement('br', { key: 0 }),
-      'bbb',
       React.createElement('br', { key: 1 }),
+      'bbb',
+      React.createElement('br', { key: 3 }),
       'ccc',
-      React.createElement('br', { key: 2 }),
+      React.createElement('br', { key: 5 }),
       'ddd'
     ];
     assert.deepEqual(expected, result);

--- a/test.js
+++ b/test.js
@@ -5,7 +5,15 @@ const assert = require('assert');
 describe('nl2br', function(){
   it('should parse newlines', function(){
     const result = nl2br('aaa\nbbb\nccc\nddd');
-    const expected = ['aaa', React.createElement('br'), 'bbb', React.createElement('br'), 'ccc', React.createElement('br'), 'ddd'];
+    const expected = [
+      'aaa',
+      React.createElement('br', { key: 0 }),
+      'bbb',
+      React.createElement('br', { key: 1 }),
+      'ccc',
+      React.createElement('br', { key: 2 }),
+      'ddd'
+    ];
     assert.deepEqual(expected, result);
   });
 


### PR DESCRIPTION
Multiple br elements cause following warning.
With react@0.14.7

```
Warning: Each child in an array or iterator should have a unique "key" prop. Check the render method of `Xxx`. See https://fb.me/react-warning-keys for more information.
```