### PR TITLE
Return given argument in any case it isn't a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,10 +4,8 @@ var React = require('react');
 var newlineRegex = /(\r\n|\r|\n)/g;
 
 module.exports = function(str) {
-  if (typeof str === 'number') {
+  if (typeof str !== 'string') {
     return str;
-  } else if (typeof str !== 'string') {
-    return '';
   }
 
   return str.split(newlineRegex).map(function(line, index) {

--- a/test.js
+++ b/test.js
@@ -23,28 +23,40 @@ describe('nl2br', function(){
     assert.deepEqual(expected, result);
   });
 
-  it('should return an empty string if the param is undefined', function () {
+  it('should return undefined if the param is undefined', function () {
     const result = nl2br(undefined);
-    const expected = '';
+    const expected = undefined;
     assert.deepEqual(expected, result);
   });
 
-  it('should return an empty string if the param is null', function () {
+  it('should return null if the param is null', function () {
     const result = nl2br(null);
-    const expected = '';
+    const expected = null;
     assert.deepEqual(expected, result);
   });
 
-  it('should return an empty string if the param is an array', function () {
+  it('should return an array if the param is an array', function () {
     const result = nl2br([]);
-    const expected = '';
+    const expected = [];
     assert.deepEqual(expected, result);
   });
 
-  it('should return an empty string if the param is an object', function () {
+  it('should return an object if the param is an object', function () {
     const result = nl2br({});
-    const expected = '';
+    const expected = {};
     assert.deepEqual(expected, result);
+  });
+  
+  it('should return a boolean if the param is a boolean', function () {
+    const result = nl2br(false);
+    const expected = false;
+    assert.deepEqual(expected, result);
+  });
+
+  it('should return the given React component if the param is a React component', function () {
+    const component = React.createElement('p', {}, 'Lorem ipsum');
+    const result = nl2br(component);
+    assert.strictEqual(component, result);
   });
 });
 


### PR DESCRIPTION
This PR makes `nl2br()` returns the argument as given in any case it isn't a string, like it already did in case of numbers. It removes the case where it returns an empty string.

Reason is that this way you can use `nl2br()` on components that will render user-supplied children, that can be both strings or React components. Think for example a dialog box component (simplified example):

```jsx
class AlertDialog {
    render() {
        return (
            <div className="AlertDialog">
                {nl2br(this.props.children)}
            </div>
        );
    }
}
```

You can now pass strings and/or component equally:

```jsx
<AlertDialog>{multilineMessageString}</AlertDialog>
<AlertDialog><p>Custom component <b>rendering</b>!</p></AlertDialog>
```

I see no drawbacks for this, arguments like `null`, `undefined` booleans, etc, will still render empty like before.