### PR TITLE
avoid using destructing assignment syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var {jsx: _jsx} = require('react/jsx-runtime');
+var jsxRuntime = require('react/jsx-runtime');
+var _jsx = jsxRuntime.jsx;
 var newlineRegex = /(\r\n|\r|\n)/g;
 
 module.exports = function(str) {


### PR DESCRIPTION
This PR prevents IE11 from crashing by avoiding the use of destructing assignment syntax that is not available in IE11.

https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Browser_compatibility (IE11 non-supported)