### PR TITLE
Switch testing from Mocha to Vitest

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,11 @@
+module.exports = [
+  {
+    files: ["**/*.js"],
+    ignores: ["node_modules/**", "eslint.config.js"],
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: "commonjs",
+    },
+    rules: {}
+  }
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,9 @@
       "version": "1.0.4",
       "license": "MIT",
       "devDependencies": {
-        "@types/react": "18.2.18",
-        "mocha": "10.0.0"
+        "@types/react": "18.2.62",
+        "eslint": "^9.0.0",
+        "vitest": "1.6.0"
       },
       "peerDependencies": {
         "react": "^15.7.0 || ^16.14.0 || ^17.0.0 || ^18.0.0"
@@ -23,8 +24,8 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.2.18",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.18.tgz",
+      "version": "18.2.62",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.62.tgz",
       "integrity": "sha512-da4NTSeBv/P34xoZPhtcLkmZuJ+oYaCxHmyHzwaDQo9RQPBeXV+06gEk2FpqEcsX9XrnNLvRpVh6bdavDSjtiQ==",
       "dev": true,
       "dependencies": {
@@ -544,83 +545,6 @@
         "node": "*"
       }
     },
-    "node_modules/mocha": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
-      "integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
-      "dev": true,
-      "dependencies": {
-        "@ungap/promise-all-settled": "1.1.2",
-        "ansi-colors": "4.1.1",
-        "browser-stdout": "1.3.1",
-        "chokidar": "3.5.3",
-        "debug": "4.3.4",
-        "diff": "5.0.0",
-        "escape-string-regexp": "4.0.0",
-        "find-up": "5.0.0",
-        "glob": "7.2.0",
-        "he": "1.2.0",
-        "js-yaml": "4.1.0",
-        "log-symbols": "4.1.0",
-        "minimatch": "5.0.1",
-        "ms": "2.1.3",
-        "nanoid": "3.3.3",
-        "serialize-javascript": "6.0.0",
-        "strip-json-comments": "3.1.1",
-        "supports-color": "8.1.1",
-        "workerpool": "6.2.1",
-        "yargs": "16.2.0",
-        "yargs-parser": "20.2.4",
-        "yargs-unparser": "2.0.0"
-      },
-      "bin": {
-        "_mocha": "bin/_mocha",
-        "mocha": "bin/mocha.js"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mochajs"
-      }
-    },
-    "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/mocha/node_modules/minimatch": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/mocha/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -977,9 +901,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "18.2.18",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.18.tgz",
-      "integrity": "sha512-da4NTSeBv/P34xoZPhtcLkmZuJ+oYaCxHmyHzwaDQo9RQPBeXV+06gEk2FpqEcsX9XrnNLvRpVh6bdavDSjtiQ==",
+      "version": "18.2.62",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.62.tgz",
+      "integrity": "sha512-PLACEHOLDER",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -1393,65 +1317,6 @@
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
-      }
-    },
-    "mocha": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
-      "integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
-      "dev": true,
-      "requires": {
-        "@ungap/promise-all-settled": "1.1.2",
-        "ansi-colors": "4.1.1",
-        "browser-stdout": "1.3.1",
-        "chokidar": "3.5.3",
-        "debug": "4.3.4",
-        "diff": "5.0.0",
-        "escape-string-regexp": "4.0.0",
-        "find-up": "5.0.0",
-        "glob": "7.2.0",
-        "he": "1.2.0",
-        "js-yaml": "4.1.0",
-        "log-symbols": "4.1.0",
-        "minimatch": "5.0.1",
-        "ms": "2.1.3",
-        "nanoid": "3.3.3",
-        "serialize-javascript": "6.0.0",
-        "strip-json-comments": "3.1.1",
-        "supports-color": "8.1.1",
-        "workerpool": "6.2.1",
-        "yargs": "16.2.0",
-        "yargs-parser": "20.2.4",
-        "yargs-unparser": "2.0.0"
-      },
-      "dependencies": {
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-          "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        },
-        "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "newlines like '\\n', '\\n\\r' to <br /> for React",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "vitest run",
+    "lint": "eslint ."
   },
   "repository": {
     "type": "git",
@@ -22,8 +23,9 @@
   "homepage": "https://github.com/yosuke-furukawa/react-nl2br#readme",
   "types": "index.d.ts",
   "devDependencies": {
-    "@types/react": "18.2.18",
-    "mocha": "10.0.0"
+    "@types/react": "18.2.62",
+    "eslint": "^9.0.0",
+    "vitest": "1.6.0"
   },
   "peerDependencies": {
     "react": "^15.7.0 || ^16.14.0 || ^17.0.0 || ^18.0.0"

--- a/test.js
+++ b/test.js
@@ -1,62 +1,77 @@
+const Module = require('module');
+const { test } = require('vitest');
+const assert = require('node:assert/strict');
+
+const React = {
+  createElement(type, props) {
+    return { type, props };
+  },
+};
+
+const originalLoad = Module._load;
+Module._load = function (request, parent, isMain) {
+  if (request === 'react/jsx-runtime') {
+    return { jsx: (type, props) => React.createElement(type, props) };
+  }
+  return originalLoad(request, parent, isMain);
+};
+
 const nl2br = require('.');
-const React = require('react');
-const assert = require('assert');
+Module._load = originalLoad;
 
-describe('nl2br', function(){
-  it('should parse newlines', function(){
-    const result = nl2br('aaa\nbbb\nccc\nddd');
-    const expected = [
-      'aaa',
-      React.createElement('br', { key: 1 }),
-      'bbb',
-      React.createElement('br', { key: 3 }),
-      'ccc',
-      React.createElement('br', { key: 5 }),
-      'ddd'
-    ];
-    assert.deepEqual(expected, result);
-  });
+test('should parse newlines', () => {
+  const result = nl2br('aaa\nbbb\nccc\nddd');
+  const expected = [
+    'aaa',
+    React.createElement('br', { key: 1 }),
+    'bbb',
+    React.createElement('br', { key: 3 }),
+    'ccc',
+    React.createElement('br', { key: 5 }),
+    'ddd',
+  ];
+  assert.deepStrictEqual(expected, result);
+});
 
-  it('should return numbers', function (){
-    const result = nl2br(42);
-    const expected = 42;
-    assert.deepEqual(expected, result);
-  });
+test('should return numbers', () => {
+  const result = nl2br(42);
+  const expected = 42;
+  assert.deepStrictEqual(expected, result);
+});
 
-  it('should return undefined if the param is undefined', function () {
-    const result = nl2br(undefined);
-    const expected = undefined;
-    assert.deepEqual(expected, result);
-  });
+test('should return undefined if the param is undefined', () => {
+  const result = nl2br(undefined);
+  const expected = undefined;
+  assert.deepStrictEqual(expected, result);
+});
 
-  it('should return null if the param is null', function () {
-    const result = nl2br(null);
-    const expected = null;
-    assert.deepEqual(expected, result);
-  });
+test('should return null if the param is null', () => {
+  const result = nl2br(null);
+  const expected = null;
+  assert.deepStrictEqual(expected, result);
+});
 
-  it('should return an array if the param is an array', function () {
-    const result = nl2br([]);
-    const expected = [];
-    assert.deepEqual(expected, result);
-  });
+test('should return an array if the param is an array', () => {
+  const arr = [];
+  const result = nl2br(arr);
+  assert.deepStrictEqual(arr, result);
+});
 
-  it('should return an object if the param is an object', function () {
-    const result = nl2br({});
-    const expected = {};
-    assert.deepEqual(expected, result);
-  });
+test('should return an object if the param is an object', () => {
+  const obj = {};
+  const result = nl2br(obj);
+  assert.deepStrictEqual(obj, result);
+});
   
-  it('should return a boolean if the param is a boolean', function () {
-    const result = nl2br(false);
-    const expected = false;
-    assert.deepEqual(expected, result);
-  });
+test('should return a boolean if the param is a boolean', () => {
+  const result = nl2br(false);
+  const expected = false;
+  assert.deepStrictEqual(expected, result);
+});
 
-  it('should return the given React component if the param is a React component', function () {
-    const component = React.createElement('p', {}, 'Lorem ipsum');
-    const result = nl2br(component);
-    assert.strictEqual(component, result);
-  });
+test('should return the given React component if the param is a React component', () => {
+  const component = React.createElement('p', {}, 'Lorem ipsum');
+  const result = nl2br(component);
+  assert.strictEqual(component, result);
 });
 


### PR DESCRIPTION
## Summary
- replace mocha with vitest in devDependencies
- update test runner script
- rewrite tests to import vitest

## Testing
- `npm test` *(fails: vitest not found)*
- `npx eslint .`
